### PR TITLE
Tweak header and layout

### DIFF
--- a/themes/paulhayes.photography/layout/_partial/footer.ejs
+++ b/themes/paulhayes.photography/layout/_partial/footer.ejs
@@ -1,5 +1,6 @@
 <footer class="site-footer">
-  <div class="site-footer-content-wrapper">
+  <div class="container">
+    <img class="footer-logo" src="/images/paul-logo-regular.png" width="132" alt="Paul Hayes Photography logo, 'Paul' written in the style of a landscape"/>
     <p>
       &copy; <%= date(new Date(), 'YYYY') %> <a href="http://paulrhayes.com">Paul Hayes</a> &mdash; <a href="/contact">Contact</a>
     </p>

--- a/themes/paulhayes.photography/layout/_partial/header.ejs
+++ b/themes/paulhayes.photography/layout/_partial/header.ejs
@@ -2,7 +2,7 @@
   <% if (!is_home()) { %>
   <a href="/" class="masthead-link">
   <% } %>
-    <img class="masthead-logo" src="/images/paul-logo-bold.png" width="170" height="73" alt="Paul Hayes Photography logo, 'Paul' written in the style of a landscape"/><br />
+    <img class="masthead-logo" src="/images/paul-logo-bold.png" width="180" height="73" alt="Paul Hayes Photography logo, 'Paul' written in the style of a landscape"/><br />
     <span class="masthead-title">Paul Hayes<br />Photography</span>
   <% if (!is_home()) { %>
   </a>

--- a/themes/paulhayes.photography/layout/_partial/header.ejs
+++ b/themes/paulhayes.photography/layout/_partial/header.ejs
@@ -1,10 +1,12 @@
-<header class="masthead container">
-  <% if (!is_home()) { %>
-  <a href="/" class="masthead-link">
-  <% } %>
+<% if (is_home()) { %>
+  <header class="masthead masthead-home container">
     <img class="masthead-logo" src="/images/paul-logo-bold.png" width="180" height="73" alt="Paul Hayes Photography logo, 'Paul' written in the style of a landscape"/><br />
     <span class="masthead-title">Paul Hayes<br />Photography</span>
-  <% if (!is_home()) { %>
-  </a>
-  <% } %>
-</header>
+  </header>
+<% } else { %>
+  <header class="masthead container">
+    <a href="/" class="masthead-link">
+      <span class="masthead-subtitle">Paul Hayes Photography</span>
+    </a>
+  </header>
+<% } %>

--- a/themes/paulhayes.photography/layout/_partial/page.ejs
+++ b/themes/paulhayes.photography/layout/_partial/page.ejs
@@ -1,7 +1,7 @@
 <main role="main">
   <article class="container article h-entry">
     <header class="article-header">
-      <h1 class="title page-title entry-title p-name">
+      <h1 class="main-content-title page-title entry-title p-name">
         <%= page.title %>
       </h1>
     </header>

--- a/themes/paulhayes.photography/layout/_partial/post/nav.ejs
+++ b/themes/paulhayes.photography/layout/_partial/post/nav.ejs
@@ -10,10 +10,10 @@
 <% if (post.prev || post.next) { %>
   <nav>
     <% if (post.prev) { %>
-      <a href="<%- config.root %><%- post.prev.path %>#photo" rel="next" data-key="left" class="nav-arrow nav-arrow-left" title="Use left and right keys to navigate">&larr; <span class="rm"> Next photo </span></a>
+      <a href="<%- config.root %><%- post.prev.path %>" rel="next" data-key="left" class="nav-arrow nav-arrow-left" title="Use left and right keys to navigate">&larr; <span class="rm"> Next photo </span></a>
     <% } %>
     <% if (post.next) { %>
-      <a href="<%- config.root %><%- post.next.path %>#photo" rel="prev" data-key="right" class="nav-arrow nav-arrow-right" title="Use left and right keys to navigate"><span class="rm"> Previous photo</span> &rarr;</a>
+      <a href="<%- config.root %><%- post.next.path %>" rel="prev" data-key="right" class="nav-arrow nav-arrow-right" title="Use left and right keys to navigate"><span class="rm"> Previous photo</span> &rarr;</a>
     <% } %>
   </nav>
 <% } %>

--- a/themes/paulhayes.photography/layout/archive.ejs
+++ b/themes/paulhayes.photography/layout/archive.ejs
@@ -1,16 +1,18 @@
-<h2 class="title page-title">
-  <%
-    if (is_archive()){
-      if (is_month()){
-        var d = moment([page.year, page.month - 1, 1]);
-        title = d.format('MMMM YYYY');
-      } else if (is_year()){
-        title = page.year;
-      } else {
-        title = 'Archive';
+<div class="container">
+  <h1 class="main-content-title page-title">
+    <%
+      if (is_archive()){
+        if (is_month()){
+          var d = moment([page.year, page.month - 1, 1]);
+          title = d.format('MMMM YYYY');
+        } else if (is_year()){
+          title = page.year;
+        } else {
+          title = 'Archive';
+        }
       }
-    }
-  %>
-  <%= title %>
-</h2>
-<%- partial('_partial/archive') %>
+    %>
+    <%= title %>
+  </h1>
+  <%- partial('_partial/archive') %>
+</div>

--- a/themes/paulhayes.photography/layout/index.ejs
+++ b/themes/paulhayes.photography/layout/index.ejs
@@ -1,1 +1,3 @@
-<%- partial('_partial/archive') %>
+<div class="container">
+  <%- partial('_partial/archive') %>
+</div>

--- a/themes/paulhayes.photography/layout/photo.ejs
+++ b/themes/paulhayes.photography/layout/photo.ejs
@@ -5,19 +5,17 @@
 %>
 <main role="main">
   <article class="container single-photo clearfix" id="photo">
+    <header class="photo-header">
+      <h1 class="main-content-title photo-title">
+        <%= photo.title %>
+      </h1>
+    </header>
     <div class="photo-image-wrapper">
       <img src="<%= photo.file %>" class="photo-image" alt="<%= photo.title %>" />
       <%- partial('_partial/post/nav', {post: photo}) %>
     </div>
-    <div class="photo-detail">
-      <header class="photo-header">
-        <h1 class="main-content-title photo-title">
-          <%= photo.title %>
-        </h1>
-      </header>
-      <div class="photo-content">
-        <%- photo.content %>
-      </div>
+    <div class="photo-content">
+      <%- photo.content %>
     </div>
     <div class="photo-meta">
       <%- partial('_partial/post/published', {post: photo}) %>

--- a/themes/paulhayes.photography/layout/tag.ejs
+++ b/themes/paulhayes.photography/layout/tag.ejs
@@ -1,4 +1,6 @@
-<h2 class="title page-title">
-  #<%= page.tag.replace(' ', '-') %>
-</h2>
-<%- partial('_partial/archive') %>
+<div class="container">
+  <h1 class="main-content-title page-title">
+    #<%= page.tag.replace(' ', '-') %>
+  </h1>
+  <%- partial('_partial/archive') %>
+</div>

--- a/themes/paulhayes.photography/source/css/master.css
+++ b/themes/paulhayes.photography/source/css/master.css
@@ -163,7 +163,6 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-weight: normal;
   color: #000;
 }
 
@@ -238,16 +237,15 @@ a:active {
 
 .masthead-link {
   display: inline-block;
-  border-bottom: 3px solid #fff;
-  padding-bottom: 15px;
+  border-bottom: 4px solid #fff;
+  padding-bottom: 14px;
   text-decoration: none;
 }
 
 .masthead-link:hover,
 .masthead-link:focus {
   text-decoration: none;
-  padding-bottom: 15px;
-  border-bottom: 3px solid;
+  border-bottom: 4px solid;
 }
 
 .title {

--- a/themes/paulhayes.photography/source/css/master.css
+++ b/themes/paulhayes.photography/source/css/master.css
@@ -162,7 +162,7 @@ body {
   }
 }
 
-h1, h2, h3, h4, h5, h6 {
+h2, h3, h4, h5, h6 {
   color: #000;
 }
 
@@ -220,10 +220,26 @@ a:active {
 
 .masthead {
   position: relative;
-  margin: 78px auto 60px;
+  margin-top: 40px;
   font-size: 1.6em;
   line-height: 1em;
-  width: 170px;
+}
+
+.masthead-home {
+  margin: 78px auto 60px;
+  width: 180px;
+}
+
+@media all and (max-width: 840px) {
+  .masthead {
+    margin-left: 30px;
+    margin-right: 30px;
+  }
+
+  .masthead-home {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .masthead-title {
@@ -231,21 +247,21 @@ a:active {
   color: #000;
 }
 
-.masthead-logo {
-  margin-bottom: 5px;
+.masthead-subtitle {
+  color: #aaa;
 }
 
 .masthead-link {
-  display: inline-block;
-  border-bottom: 4px solid #fff;
-  padding-bottom: 14px;
   text-decoration: none;
 }
 
 .masthead-link:hover,
 .masthead-link:focus {
-  text-decoration: none;
-  border-bottom: 4px solid;
+  color: #aaa;
+}
+
+.masthead-logo {
+  margin-bottom: 5px;
 }
 
 .title {
@@ -257,35 +273,17 @@ a:active {
   font-weight: bold;
 }
 
-.page-title {
-  max-width: 780px;
-  margin: 0 auto;
-  padding: 12px 20px 0;
-  font-size: 1.2em;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-}
-
 .main-content-title {
-  color: #333;
+  color: #000;
   font-size: 2.6666666667em; /* 64px/24px */
   line-height: 1.25; /* 80/64px */
-  margin: 1.375em auto 0.84375em; /* 88/64px,  88/54px */
-  text-align: center;
-}
-
-.photo-title {
-  margin: 42px 0 24px;
-  text-align: left;
+  margin: 1.375em 0 0.84375em -40px; /* 88/64px,  88/54px */
   font-size:  1.75em;
 }
 
-@media all and (max-width: 620px) {
-  .main-content-title {
-    font-size: 2em;
-    padding: 0;
-  }
+.photo-title,
+.page-title {
+  margin: 0 0 24px;
 }
 
 /* ==========================================================================
@@ -293,8 +291,7 @@ a:active {
  ========================================================================== */
 
 .listing {
-  width: 790px;
-  margin: 0 auto;
+  margin: 0 -40px;
 }
 
 .listing-item {
@@ -348,19 +345,13 @@ a:active {
 
 .site-footer {
   font-size: 0.8em;
-  padding: 0 30px 1.66666667em; /* 32/24px */
+  padding: 60px 0 1.66666667em; /* 32/24px */
   clear: both;
   margin: 2em 0 0;
 }
 
 .site-footer p {
   margin-bottom: 5px;
-}
-
-.site-footer-content-wrapper {
-  margin: 0 auto;
-  max-width: 780px;
-  text-align: center;
 }
 
 .site-footer a {
@@ -372,27 +363,18 @@ a:active {
   text-decoration: underline;
 }
 
-/* ==========================================================================
- Pages
- ========================================================================== */
-
-.article-content {
-  margin: 42px 0;
-  padding: 0 20px;
+.footer-logo {
+  opacity: 0.6;
 }
 
 /* ==========================================================================
  Photos
  ========================================================================== */
 
-.single-photo {
-  margin-top: -42px;
-  padding-top: 42px;
-  padding-bottom: 24px;
-}
-
 .photo-image {
   max-width: 100%;
+  max-height: 860px;
+  text-align: center;
 }
 
 .photo-image-wrapper {
@@ -401,6 +383,11 @@ a:active {
   background: #eee;
   position: relative;
   line-height: 0;
+  text-align: center;
+}
+
+.article-tag-list {
+  margin-bottom: 0;
 }
 
 .article-tag-list-item {
@@ -408,11 +395,21 @@ a:active {
   margin-right: 1em;
 }
 
+@media all and (max-width: 540px) {
+  .article-tag-list-item {
+    display: block;
+  }
+}
+
 @media all and (max-width: 880px) {
   .photo-image-wrapper {
     margin-left: -30px;
     margin-right: -30px;
   }
+}
+
+.photo-content {
+  margin-top: 42px;
 }
 
 .photo-meta {

--- a/themes/paulhayes.photography/source/js/master.js
+++ b/themes/paulhayes.photography/source/js/master.js
@@ -5,7 +5,6 @@
 function bindKeyToLink() {
   var element = $(this);
   Mousetrap.bind(element.data('key'), function() {
-    element.focus();
     window.location.href = element.attr('href');
   });
 }


### PR DESCRIPTION
# Before
<img width="1230" alt="screen shot 2015-10-02 at 23 28 55" src="https://cloud.githubusercontent.com/assets/319055/10259207/95178354-695d-11e5-9e81-673901e5d1fe.png">
<img width="1231" alt="screen shot 2015-10-02 at 23 30 06" src="https://cloud.githubusercontent.com/assets/319055/10259209/96465bce-695d-11e5-9466-4b0e05f478ed.png">

# After
<img width="1229" alt="screen shot 2015-10-02 at 23 29 06" src="https://cloud.githubusercontent.com/assets/319055/10259211/97fb5d52-695d-11e5-90a1-39166a2498cb.png">
<img width="1231" alt="screen shot 2015-10-02 at 23 30 12" src="https://cloud.githubusercontent.com/assets/319055/10259212/9804b8de-695d-11e5-87ff-31024ba710f5.png">


* Don’t use large logo above photos, instead use a breadcrumb like
design. The page no longer shifts up and down when navigating.
* Include the logo in the footer and left align. This keeps the left
edge of content consistent and makes photo lists with fewer than 4
shots not look so weird.
* Restrict maximum height of images so that long profile shots can be
more easily viewed on landscape devices
* Use the same title styles for photos, archives and tags