### PR TITLE
Add tools for managing photo keywords

### DIFF
--- a/generators/export_keywords_to_images.rb
+++ b/generators/export_keywords_to_images.rb
@@ -1,0 +1,142 @@
+#!/usr/bin/ruby
+gem 'mini_exiftool', '2.8.0'
+gem 'exifr', '1.2.3.1'
+require 'optparse'
+require 'mini_exiftool'
+require 'exifr'
+require "./#{File.dirname(__FILE__)}/keyword_map.rb"
+keyword_map = KeywordMap.new
+
+# Get list of all posts
+path_to_images = "#{Dir.pwd}/../paulhayes.photography-photos/"
+posts = Dir.glob("source/_posts/photos/*.md")
+
+# posts.each do |post|
+#   image = post.split('/').last.sub(/md$/, 'jpg')
+#   puts "[\"#{image}\", %w{}, %w{}],"
+# end
+
+images = [
+  ["amur-leopard-snarl.jpg", %w{big_cat portrait}, %w{parus orientalis panthera_pardus_orientalis amur amur_leopard leopard snarl angry danger hiss teeth jaw scare far_eastern_leopard critically_endangered}],
+  ["amur-leopard.jpg", %w{big_cat portrait}, %w{parus orientalis panthera_pardus_orientalis amur amur_leopard leopard prowl walking far_eastern_leopard critically_endangered}],
+  ["an-autumn-day.jpg", %w{land english fantasy}, %w{national_trust lord_of_the_rings wakehurst_place kew_gardens kew park leaves bench sussex wakehurst inviting path}],
+  ["autumn-colours.jpg", %w{sheffield_park forest fantasy land}, %w{yellow}],
+  ["autumn-light.jpg", %w{sheffield_park forest fantasy land}, %w{yellow}],
+  ["azaleas.jpg", %w{sheffield_park flower macro}, %w{pink azalea azaleas rhododendron}],
+  ["azure-clatteringshaws.jpg", %w{loch calm blue_sky land}, %w{clatteringshaws galloway dumfries national_park}],
+  ["blackbrook-woods.jpg", %w{bluebells forest land}, %w{blackbrook}],
+  ["blade-runner.jpg", %w{sci_fi moon astro}, %w{blade_runner}],
+  ["bluebell-bloom.jpg",  %w{bluebells forest land}, %w{blackbrook}],
+  ["brae-of-achnahaird.jpg", %w{highlands}, %w{beach frozen_beach sand}],
+  ["brighton-beach-low-tide.jpg", %w{palace_pier dawn moon}, %w{low_tide}],
+  ["brighton-pavilion-twilight.jpg", %w{pavilion twilight}, %w{purple}],
+  ["brighton-pavilion.jpg", %w{pavilion twilight}, %w{blue}],
+  ["brighton-pier-supermoon.jpg", %w{moon night palace_pier }, %w{supermoon super_moon big_moon}],
+  ["brighton-starlings.jpg", %w{starlings twilight palace_pier}, %w{low_tide reflection}],
+  ["brighton-west-pier.jpg", %w{west_pier sunset}, %w{}],
+  ["cadaques.jpg", %w{calm blue_sky}, %w{architecture spain cadaques europe european spanish remote town small}],
+  ["centre-of-our-galaxy.jpg", %w{milky_way seychelles}, %w{}],
+  ["clatteringshaws-before-dawn.jpg",  %w{loch dawn mist}, %w{clatteringshaws galloway dumfries national_park}],
+  ["clatteringshaws-dawn.jpg", %w{loch dawn mist}, %w{clatteringshaws galloway dumfries national_park}],
+  ["clatteringshaws-mist-and-reflections.jpg", %w{loch dawn mist}, %w{clatteringshaws galloway dumfries national_park}],
+  ["corsewall-on-the-rocks.jpg", %w{scotland land}, %w{corsewall lighthouse abstract upside_down different rocks interesting}],
+  ["cowpaths.jpg", %w{devils_dyke}, %w{}],
+  ["dawn-ascent.jpg", %w{dawn}, %w{balloons balloon_fiesta bristol silhouette}],
+  ["devils-dyke-sunset.jpg", %w{devils_dyke sunset}, %w{}],
+  ["elphin.jpg", %w{highlands frost calm}, %w{cul_mor elphin derelict abandoned remote grass house}],
+  ["esthwaite.jpg", %w{mist dawn lake_district}, %w{esthwaite ambleside dragon}],
+  ["first-dance.jpg", %w{black_and_white}, %w{wedding people dance dancing couple love first_dance}],
+  ["fox-profile.jpg", %w{fox}, %w{}, %w{fox red_fox}, %w{prowling watching hunting}],
+  ["fox.jpg", %w{fox}, %w{}, %w{fox red_fox}, %w{prowling watching hunting}],
+  ["frosty-abstract-1.jpg", %w{frost land abstract}, %w{hoar_frost lindfield detail}],
+  ["frosty-abstract-2.jpg", %w{frost land abstract}, %w{hoar_frost lindfield detail}],
+  ["frosty-abstract-3.jpg", %w{frost land abstract}, %w{hoar_frost lindfield detail}],
+  ["frosty-abstract-4.jpg", %w{frost land abstract}, %w{hoar_frost lindfield detail}],
+  ["frosty-glow.jpg", %w{frost dawn land}, %w{hoar_frost lindfield detail}],
+  ["frosty-lindfield.jpg", %w{frost land abstract}, %w{hoar_frost lindfield detail}],
+  ["frozen-beach.jpg", %w{scotland frost land}, %w{frozen_beach beach sand}],
+  ["great-argus.jpg", %w{bird borneo}, %w{great_argus argus danum_valley tropical}],
+  ["great-langdale.jpg", %w{lake_district overcast}, %w{langdale great_langdale}],
+  ["great-tit.jpg", %w{bird portrait england}, %w{parus_major parus paridae}, %w{great_tit}, %w{perching sitting watching waiting}],
+  ["grey-wagtail.jpg", %w{bird portrait england}, %w{motacilla_cinerea}, %w{wagtail grey_wagtail}, %w{eating_bug holding_bug eating_insect catching_fly}],
+  ["harvest-mouse-on-wheat.jpg", %w{mammal england}, %w{wheatear precarious}, %w{mouse harvest_mouse micromys}, %w{climbing balancing on_wheat}],
+  ["harvest-mouse.jpg", %w{mammal england}, %w{wheatear precarious}, %w{mouse harvest_mouse micromys}, %w{climbing balancing on_wheat}],
+  ["hong-kong.jpg", %w{city night sci_fi landscape}, %w{hong_kong china victoria skyscraper skyscrapers}],
+  ["iguacu-falls.jpg", %w{land}, %w{brazil waterfall}],
+  ["iguana.jpg", %w{wildlife costa_rica portrait}, %w{reptile lizard}, %w{lizard iguana}, %w{watching sitting staring portrait}],
+  ["illuminating-the-milky-way.jpg", %w{milky_way scotland}, %w{lighthouse shining corsewall}],
+  ["kielder-forest.jpg", %w{forest land abstract}, %w{}, %w{kielder northumberland}, %w{forest wood woods trees}],
+  ["kielder-observatory.jpg", %w{astro}, %w{obsy}, %w{observatory kielder_observatory}, %w{under_stars beneath_stars at_night}],
+  ["kota-kinabalu-sunset.jpg", %w{sunset landscape calm borneo sea}, %w{kota_kinabalu}],
+  ["kuching.jpg", %w{calm city borneo}, %w{kuching}],
+  ["langdale-light.jpg", %w{lake_district}, %w{ray_of_light shaft_of_light clouds_opening langdale}],
+  ["lightning-brighton-station.jpg", %w{brighton night city overcast black_and_white}, %w{lightning}],
+  ["lightning-brighton.jpg", %w{brighton night city overcast sea}, %w{}, %w{lightning}, %w{strike spark fork}],
+  ["loch-assynt-panorama.jpg", %w{loch highlands dawn}, %w{assynt loch_assynt}],
+  ["loch-assynt.jpg", %w{loch highlands dawn}, %w{assynt loch_assynt}],
+  ["loch-skeen.jpg", %w{loch land}, %w{skeen hike trail walk}],
+  ["longsheng-rice-terraces.jpg", %w{land calm}, %w{rice_terrace rice_terraces yellow china longsheng pingan}],
+  ["marloes-sands.jpg", %w{sea landscape uk}, %w{wales pembrokeshire marloes}],
+  ["mirror-lake-jiuzhaigou.jpg", %w{landscape lake calm}, %w{china jiuzhaigou}, %w{lake mirror_lake turquoise_lake}, %w{reflection serene}],
+  ["our-galaxy.jpg", %w{milky_way england}, %w{beachy_head}],
+  ["pheasant-portrait.jpg", %w{bird portrait}, %w{sheffield_park national_trust}, %w{pheasant}, %w{posing portrait closeup colours color}],
+  ["pitstone-windmill.jpg", %w{land sunset}, %w{}, %w{windmill pitstone_windmill chilterns ivinghoe}, %w{with_clouds evening}],
+  ["polecat.jpg", %w{mammal england flowers}, %w{sussex carnivora}, %w{polecat ferret}, %w{portrait closeup watching peeking staring smelling}],
+  ["poppy-field.jpg", %w{flowers sunset brighton}, %w{}, %w{poppy red_poppy}, %w{field fields}],
+  ["red-panda.jpg", %w{mammal}, %w{china chengdu}, %w{red_panda}, %w{looking watching sniffing staring}],
+  ["resplendent-quetzal.jpg", %w{bird costa_rica portrait}, %w{}, %w{quetzal resplendent_quetzal}, %w{sitting perching}],
+  ["seal-posing.jpg", %w{mammal scotland}, %w{stranraer}, %w{seal grey_seal}, %w{posing sitting waiting by_sea in_harbour}],
+  ["seven-sisters-dawn.jpg", %w{sussex dawn sea}, %w{}, %w{seven_sisters}, %w{at_dawn morning sunlight}],
+  ["sky-rise.jpg", %w{sci_fi city black_and_white abstract}, %w{london neo architecture}],
+  ["sleepwalking.jpg", %w{seychelles night sea calm}, %w{sleepwalking}],
+  ["snow-tree.jpg", %w{frost south_downs}, %w{snow tree}],
+  ["south-downs-falmer.jpg", %w{south_downs}, %w{falmer green}],
+  ["starlings.jpg", %w{starlings palace_pier sea}, %w{}],
+  ["starry-arch.jpg", %w{seychelles astro milky_way}, %w{arch starry}],
+  ["striped-blue-crow-butterfly.jpg", %w{wildlife}, %w{insect butterfly blue_crow_butterfly china longsheng pingan}],
+  ["summer-poppies.jpg", %w{flowers sunset brighton}, %w{}, %w{poppy red_poppy}, %w{field fields}],
+  ["sunbird.jpg", %w{bird borneo flower}, %w{kota_kinabalu}, %w{sunbird}, %w{perching sitting on_branch flower}],
+  ["superbloodmoon-rottingdean.jpg", %w{moon astro sussex}, %w{rottingdean windmill composition supermoon superblood_moon superbloodmoon}],
+  ["tawny-owl.jpg", %w{bird}, %w{strix aluco}, %w{owl tawny_owl}, %w{tree tree_trunk perching daylight sitting}],
+  ["the-bandstand.jpg", %w{brighton night city sea}, %w{bandstand the_bandstand}],
+  ["the-gloaming.jpg", %w{land abstract}, %w{purple chilterns ivinghoe}],
+  ["thirlmere.jpg", %w{lake_district overcast}, %w{thirlmere}],
+  ["tiger.jpg", %w{big_cat}, %w{bamboo}, %w{tiger bengal_tiger}, %w{staring prowling walking moving hunting}],
+  ["tree-in-bluebells.jpg", %w{bluebells forest land sussex}, %w{blackbrook}],
+  ["twilight-sands.jpg", %w{twilight sunset sea}, %w{marloes sands pembrokeshire}],
+  ["two-trees.jpg", %w{}, %w{}],
+  ["west-beach-sunset.jpg", %w{seychelles sunset sea calm}, %w{west_beach volunteering conservation}],
+  ["west-beach.jpg", %w{seychelles sea calm blue_sky}, %w{west_beach volunteering conservation}],
+  ["west-pier-blue.jpg", %w{west_pier}, %w{}],
+  ["west-pier-dreamy.jpg", %w{west_pier sunset}, %w{dreamy colourful colours}],
+  ["west-pier-halloween.jpg", %w{west_pier sunrise}, %w{halloween pink}],
+  ["west-pier-hot-and-cold.jpg", %w{west_pier sunset}, %w{hot_and_cold hot cold}],
+  ["west-pier-purple-murmuration.jpg", %w{west_pier starlings sunset}, %w{}],
+  ["west-pier-rust.jpg", %w{west_pier birds abstract}, %w{rust}],
+  ["west-pier-sunset.jpg", %w{west_pier sunset}, %w{silhouette sun}],
+  ["wild-goat.jpg", %w{wildlife scotland}, %w{}, %w{goat wild_goat}, %w{chewing eating looking staring}],
+]
+
+images.each do |image|
+  filename = image[0]
+  keyword_types = image[1]
+  keywords = image[2]
+  keyword_nouns = image[3]
+  keyword_modifiers = image[4]
+
+  photo = MiniExiftool.new("#{path_to_images}#{filename}")
+  exif = EXIFR::JPEG.new("#{path_to_images}#{filename}")
+
+  existing_keywords = photo.keywords || []
+  if keyword_nouns && keyword_modifiers
+    modified_keywords = keyword_map.nouns_with_modifiers(keyword_nouns, keyword_modifiers)
+    existing_keywords.concat(modified_keywords)
+  end
+
+  new_keywords = keyword_map.keywords_with_exif(exif, keyword_types, existing_keywords + keywords)
+  puts "#{image[0]}: #{new_keywords.join(', ')} (#{new_keywords.size})\n\n"
+  photo.keywords = new_keywords
+  photo.save
+end
+
+exit

--- a/generators/export_titles_to_images.rb
+++ b/generators/export_titles_to_images.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/ruby
+gem 'mini_exiftool', '2.8.0'
+require 'mini_exiftool'
+
+# Get list of all posts
+path_to_images = "#{Dir.pwd}/../paulhayes.photography-photos/"
+posts = Dir.glob("source/_posts/photos/*.md")
+
+posts.each do |post|
+  post_contents = File.read(post)
+  image = post.split('/').last.sub(/md$/, 'jpg')
+  photo = MiniExiftool.new("#{path_to_images}#{image}")
+  edited = false
+
+  title = post_contents.lines.find {|l| l.include?('title:')}.gsub('title: ', '').gsub('"', '')
+
+  if !photo.creator
+    edited = true
+    photo.creator = 'Paul Hayes'
+  end
+
+  if !photo.copyright_notice
+    photo.copyright_notice = 'Paul Hayes www.paulhayes.photography'
+    edited = true
+  end
+
+  if !photo.title && title
+    photo.title = title
+    edited = true
+    puts "Photo #{image} title being set to: #{title}"
+  else
+    puts "Photo #{image} already has a title"
+  end
+
+  if edited
+    puts "Saving changes to #{image}"
+    photo.save
+  end
+
+  #exit
+end
+
+exit

--- a/generators/keyword_map.rb
+++ b/generators/keyword_map.rb
@@ -2,17 +2,25 @@ require 'time'
 
 class KeywordMap
   def keywords_with_exif(exif, types = [], keys = [])
-    exposure = exif.exposure_time.to_f
-    types << 'long_exposure' if exposure > 5
+    if exif && exif.exposure_time
+      exposure = exif.exposure_time.to_f
+      types << 'long_exposure' if exposure > 5
+    end
 
-    month = exif.date_time_original.strftime('%B').downcase
-    keys << month
-    types << 'summer' if %w{june july august}.include?(month)
-    types << 'autumn' if %w{september october november}.include?(month)
-    types << 'winter' if %w{december january february}.include?(month)
-    types << 'spring' if %w{march april may}.include?(month)
+    if exif && exif.date_time_original
+      month = exif.date_time_original.strftime('%B').downcase
+      keys << month
+      types << 'summer' if %w{june july august}.include?(month)
+      types << 'autumn' if %w{september october november}.include?(month)
+      types << 'winter' if %w{december january february}.include?(month)
+      types << 'spring' if %w{march april may}.include?(month)
+    end
 
     keywords(types, keys)
+  end
+
+  def nouns_with_modifiers(nouns = [], modifiers = [])
+    nouns + modifiers + nouns.product(modifiers).map{ |i| i.join('_')}
   end
 
   def keywords(types = [], keys = [])
@@ -26,6 +34,10 @@ class KeywordMap
 
     keys.concat(paul_hayes)
     keys.map {|k| k.gsub('_', ' ') }.uniq
+  end
+
+  def bird
+    birds
   end
 
   def birds
@@ -42,15 +54,28 @@ class KeywordMap
     } + wildlife
   end
 
+  def starlings
+    %w{
+      starlings
+      murmuration
+      murmurating
+      murmurating_starlings
+      flock_of_birds
+      flock
+      sturnidae
+      passerine
+    } + birds
+  end
+
   def wildlife
     %w{
       wildlife
-      wild
       animal
       animals
       nature
       wildlife_photography
       natural
+      nature
       fauna
       animal_portrait
     }
@@ -62,6 +87,8 @@ class KeywordMap
       landscape_photography
       outdoors
       travel
+      vista
+      picturesque
     }
   end
 
@@ -108,9 +135,32 @@ class KeywordMap
     %w{
       sheffield_park
       national_trust
+      gardens
+      garden
       trees
       tree
     } + english
+  end
+
+  def forest
+    %w{
+      forest
+      wood
+      woods
+      trees
+      leaves
+      tall
+      nature
+    }
+  end
+
+  def borneo
+    %w{
+      borneo
+      malaysia
+      jungle
+      wild
+    }
   end
 
   def uk
@@ -120,6 +170,20 @@ class KeywordMap
     }
   end
 
+  def costa_rica
+    %w{
+      costa_rica
+      central_america
+      americas
+      new_world
+      pura_vida
+    }
+  end
+
+  def england
+    english
+  end
+
   def english
     %w{
       english
@@ -127,14 +191,28 @@ class KeywordMap
     } + uk
   end
 
+  def lake_district
+    %w{
+      lake_district
+      the_lakes
+      lake
+      lakes
+      cumbria
+      northwest_england
+    } + land + england
+  end
+
   def brighton
     %w{
       brighton
-      sussex
-      england
       south_coast
-      southern_england
-    } + english
+    } + sussex
+  end
+
+  def devils_dyke
+    %w{
+      devils_dyke
+    } + south_downs
   end
 
   def south_downs
@@ -151,6 +229,13 @@ class KeywordMap
     } + brighton + land
   end
 
+  def sussex
+    %w{
+      sussex
+      southern_england
+    } + england
+  end
+
   def west_pier
     %w{
       west_pier
@@ -161,6 +246,28 @@ class KeywordMap
       disappearing
       decay
     } + sea + brighton
+  end
+
+  def palace_pier
+    %w{
+      palace_pier
+      brighton_pier
+      pier
+      architecture
+      seaside_town
+      seaside_attractions
+      arcades
+    } + sea + brighton
+  end
+
+  def pavilion
+    %w{
+      brighton_pavilion
+      royal_pavilion
+      architecture
+      brighton_palace
+      pavilion
+    } + brighton
   end
 
   def sea
@@ -184,6 +291,17 @@ class KeywordMap
       mammal
       mammals
     } + wildlife
+  end
+
+  def fantasy
+    %w{
+      fantasy
+      magical
+      middle_earth
+      beautiful
+      mystical
+      tolkien
+    }
   end
 
   def fox
@@ -227,14 +345,13 @@ class KeywordMap
     %w{
       cold
       winter
-      frost
-      frosty
     }
   end
 
   def spring
     %w{
       spring
+      springtime
     }
   end
 
@@ -250,6 +367,232 @@ class KeywordMap
       autumn
       fall
       autumnal
+      autumn_colours
+    }
+  end
+
+  def frost
+    %w{
+      frost
+      frosty
+      frostbite
+    } + winter
+  end
+
+  def big_cat
+    %w{
+      big_cat
+      predator
+      carnivore
+      cat
+      cats
+      fauna
+      panthera
+      endangered
+    } + wildlife + mammal
+  end
+
+  def flower
+    flowers + macro
+  end
+
+  def flowers
+    %w{
+      flower
+      flowers
+      plant
+      flora
+      blossom
+      bloom
+    }
+  end
+
+  def bluebells
+    %w{
+      bluebell
+      bluebells
+      purple
+      purple flowers
+    } + flowers + uk
+  end
+
+  def macro
+    %w{
+      macro
+      small
+      detail
+    }
+  end
+
+  def scotland
+    %w{
+      scotland
+      scottish
+    } + uk
+  end
+
+  def highlands
+    %w{
+      highlands
+      mountain
+      mountains
+      snow
+      snowy
+    } + land + scotland
+  end
+
+  def lake
+    %w{
+      lake
+      water
+      reflection
+      water_body
+    }
+  end
+
+  def loch
+    %w{
+      loch
+    } + lake + scotland
+  end
+
+  def blue_sky
+    %w{
+      blue_sky
+      clear_sky
+      azure
+      fairweather
+      nice_weather
+    }
+  end
+
+  def calm
+    %w{
+      calm
+      holiday
+      tranquil
+      peaceful
+      quiet
+      relaxing
+      relax
+      serene
+      serenity
+      halcyon
+      idyllic
+      blissful
+      picturesque
+    }
+  end
+
+  def night
+    %w{
+      night
+      night_time
+      nightscape
+      dark
+    }
+  end
+
+  def city
+    %w{
+      city
+      city_lights
+      cityscape
+    }
+  end
+
+  def sci_fi
+    %w{
+      sci_fi
+      scifi
+      futuristic
+    } + city
+  end
+
+  def astro
+    %w{
+      astro
+      astrophotography
+      star
+      stars
+      space
+      universe
+    } + night
+  end
+
+  def milky_way
+    %w{
+      milky_way
+      milkyway
+      galaxy
+      our_galaxy
+      stardust
+      star_dust
+    } + astro
+  end
+
+  def moon
+    %w{
+      moon
+      luna
+      the_moon
+    }
+  end
+
+  def dawn
+    %w{
+      dawn
+      sunrise
+      morning
+      morning_light
+      start_of_the_day
+    }
+  end
+
+  def sunset
+    %w{
+      sunset
+      dusk
+      evening
+      evening_light
+      end_of_the_day
+    }
+  end
+
+  def twilight
+    %w{
+      twilight
+      evening
+      blue_hour
+    } + night
+  end
+
+  def seychelles
+    %w{
+      seychelles
+      north_island
+      island
+      remote
+      remote_island
+      holiday
+    }
+  end
+
+  def mist
+    %w{
+      mist
+      misty
+      fog
+      foggy
+      low_cloud
+    } + land
+  end
+
+  def abstract
+    %w{
+      abstract
+      different
+      alternative
     }
   end
 end

--- a/generators/keyword_map.rb
+++ b/generators/keyword_map.rb
@@ -1,0 +1,255 @@
+require 'time'
+
+class KeywordMap
+  def keywords_with_exif(exif, types = [], keys = [])
+    exposure = exif.exposure_time.to_f
+    types << 'long_exposure' if exposure > 5
+
+    month = exif.date_time_original.strftime('%B').downcase
+    keys << month
+    types << 'summer' if %w{june july august}.include?(month)
+    types << 'autumn' if %w{september october november}.include?(month)
+    types << 'winter' if %w{december january february}.include?(month)
+    types << 'spring' if %w{march april may}.include?(month)
+
+    keywords(types, keys)
+  end
+
+  def keywords(types = [], keys = [])
+    types.each do |type|
+      begin
+        keys.concat(self.send(type))
+      rescue
+        puts "Warning: No type “#{type}” found"
+      end
+    end
+
+    keys.concat(paul_hayes)
+    keys.map {|k| k.gsub('_', ' ') }.uniq
+  end
+
+  def birds
+    %w{
+      bird
+      birds
+      aves
+      avian
+      wings
+      feathers
+      flying
+      birding
+      bird_portrait
+    } + wildlife
+  end
+
+  def wildlife
+    %w{
+      wildlife
+      wild
+      animal
+      animals
+      nature
+      wildlife_photography
+      natural
+      fauna
+      animal_portrait
+    }
+  end
+
+  def landscape
+    %w{
+      landscape
+      landscape_photography
+      outdoors
+      travel
+    }
+  end
+
+  def land
+    %w{
+      land
+      light_on_land
+      adventure
+    } + landscape
+  end
+
+  def overcast
+    %w{
+      moody
+      overcast
+      epic
+      adventure
+      heavy
+      powerful
+      stormy
+      storm
+      clouds
+    }
+  end
+
+  def paul_hayes
+    %w{
+      paul_hayes
+      paul_hayes_photography
+    }
+  end
+
+  def black_and_white
+    %w{
+      black_and_white
+      b&w
+      b+w
+      black_white
+      tones
+    }
+  end
+
+  def sheffield_park
+    %w{
+      sheffield_park
+      national_trust
+      trees
+      tree
+    } + english
+  end
+
+  def uk
+    %w{
+      uk
+      british
+    }
+  end
+
+  def english
+    %w{
+      english
+      england
+    } + uk
+  end
+
+  def brighton
+    %w{
+      brighton
+      sussex
+      england
+      south_coast
+      southern_england
+    } + english
+  end
+
+  def south_downs
+    %w{
+      south_downs
+      rolling_hills
+      downs
+      hills
+      farm
+      farmland
+      slopes
+      pasture
+      pattern
+    } + brighton + land
+  end
+
+  def west_pier
+    %w{
+      west_pier
+      pier
+      architecture
+      deteriorate
+      structure
+      disappearing
+      decay
+    } + sea + brighton
+  end
+
+  def sea
+    %w{
+      sea
+      seaside
+      beach
+      sand
+      coast
+      water
+      seascape
+      waves
+      ocean
+      outdoors
+      travel
+    }
+  end
+
+  def mammal
+    %w{
+      mammal
+      mammals
+    } + wildlife
+  end
+
+  def fox
+    %w{
+      fox
+      foxy
+      red_fox
+      british_fox
+      british_wildlife
+      fox_portrait
+      fox_daylight
+      fox_field
+      european_fox
+      fur
+      red
+      orange
+      predator
+      carnivore
+      vulpes
+    } + mammal
+  end
+
+  def portrait
+    %w{
+      close_up
+      closeup
+      portrait
+      head
+      face
+    }
+  end
+
+  def long_exposure
+    %w{
+      long_exposure
+      long
+    }
+  end
+
+  def winter
+    %w{
+      cold
+      winter
+      frost
+      frosty
+    }
+  end
+
+  def spring
+    %w{
+      spring
+    }
+  end
+
+  def summer
+    %w{
+      summer
+      warm
+    }
+  end
+
+  def autumn
+    %w{
+      autumn
+      fall
+      autumnal
+    }
+  end
+end

--- a/generators/keywords.rb
+++ b/generators/keywords.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/ruby
+# Dependency: brew install ExifTool
+# http://www.sno.phy.queensu.ca/~phil/exiftool/
+# https://github.com/janfri/mini_exiftool
+
+# 500px limit: 30 keywords
+# Stock limit: 50 keywords
+gem 'mini_exiftool', '2.8.0'
+gem 'exifr', '1.2.3.1'
+require 'optparse'
+require 'mini_exiftool'
+require 'exifr'
+require "./#{File.dirname(__FILE__)}/keyword_map.rb"
+
+keyword_map = KeywordMap.new
+options = {}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: keywords.rb #{$0} [options]"
+  opts.on("-t", "--types [TYPES]", Array, "Types of keyword to include") do |types|
+    types.each do |type|
+      unless keyword_map.respond_to?(type)
+        puts "Invalid type provided: #{type}"
+        exit
+      end
+    end
+    options[:types] = types
+  end
+
+  opts.on("-l", "--list-types", "List keyword types") do
+    puts KeywordMap.instance_methods(false).sort
+    exit
+  end
+
+  opts.on("-f", "--file [path_to_file]", String, "Path to image") do |file|
+    options[:path] = file
+  end
+
+  opts.on("-k", "--keywords [KEYWORDS]", Array, "Extra keywords") do |keywords|
+    options[:keywords] = keywords
+  end
+
+  opts.on("-p", "--keywords-path [path_to_file]", Array, "Extra keywords file") do |keywords_path|
+    options[:keywords_path] = keywords_path
+  end
+end.parse!
+
+# Provide path to image as first argument
+path_to_image = options[:path]
+
+if !path_to_image
+  puts "No image specified"
+  exit
+end
+
+if !File.exists?(path_to_image)
+  puts "File not found: #{path_to_image}"
+  exit
+end
+
+exif = EXIFR::JPEG.new(path_to_image)
+photo = MiniExiftool.new(path_to_image)
+
+if !exif || !photo
+  puts "No exif"
+  exit
+end
+
+options_types = options[:types] || []
+options_keywords = options[:keywords] || []
+existing_keywords = photo.keywords || []
+new_keywords = keyword_map.keywords_with_exif(exif, options_types, existing_keywords + options_keywords)
+
+puts new_keywords
+photo.keywords = new_keywords
+
+puts 'Saving…'
+photo.save
+
+exit

--- a/generators/regenerate-exif.rb
+++ b/generators/regenerate-exif.rb
@@ -6,7 +6,7 @@ include ExifHelper
 
 # Get list of all posts
 path_to_images = "#{Dir.pwd}/../paulhayes.photography-photos/"
-posts = Dir.glob("source/_posts/*.md")
+posts = Dir.glob("source/_posts/photos/*.md")
 
 posts.each do |post|
   post_contents = File.read(post)


### PR DESCRIPTION
* Make it easier to tag photos by grouping common keywords based on themes
* Specify groups of keywords
* Save keywords in image file for extraction on upload to websites
* Extract post titles and save as IPTC tag
* Add missing copyright IPTC tags
* Add keywords to all site photos, keep a record of choices

Resized and watermarked images re-regenerated after updates to cascade keywords, title and copyright.

Example output:
```
clatteringshaws-mist-and-reflections.jpg: clatteringshaws, galloway, dumfries, national park, september, loch, lake, water, reflection, water body, scotland, scottish, uk, british, dawn, sunrise, morning, morning light, start of the day, mist, misty, fog, foggy, low cloud, land, light on land, adventure, landscape, landscape photography, outdoors, travel, vista, picturesque, autumn, fall, autumnal, autumn colours, paul hayes, paul hayes photography (39)
```